### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "echo hello world"

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ $ g++ mainPage.cpp -lGL -lGLU -lglut -o SkyBlue3D && ./SkyBlue3D
  
  ![alt tag](https://raw.githubusercontent.com/DeekshithShetty/Pokemon-SkyBlue-3D-Version/master/Snapshots/snapshot-5.png)
 
+[![Run on Repl.it](https://repl.it/badge/github/DeekshithShetty/pokemon-skyblue-3d)](https://repl.it/github/DeekshithShetty/pokemon-skyblue-3d)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@XxStabberXx/pokemon-skyblue-3d-1).